### PR TITLE
Increase sleep time, to give enough time for Entrypoint to chown home area

### DIFF
--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
 
                                     echo "Starting containers"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d $TEST_SERVICE
-                                    sleep 10
+                                    sleep 20
 
                                     '''
 


### PR DESCRIPTION
Some slices in PR builds would sometimes fail with "Rucio: permission denied" which is related to some commands in the EntryPoint not being executed yet.

The increase in sleep time helps with this.