### PR TITLE
Fixes dmwm/WMCore#12187

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ DMWM-old
 jenkins_python
 contents
 reference
+*/**/.DS_Store

--- a/ContainerScripts/AggregatePylint.py
+++ b/ContainerScripts/AggregatePylint.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python3
+
+import json
+
+from optparse import OptionParser
+
+usage = "usage: %prog [options] message"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a label")
+
+label = args[0]
+
+try:
+    with open('pylintReport.json', 'r') as reportFile:
+        report = json.load(reportFile)
+except IOError:
+    report = {}
+
+warnings = 0
+errors = 0
+comments = 0
+refactors = 0
+score = 0
+
+with open('pylint.out', 'r') as pylintFile:
+    for line in pylintFile:
+        if line.startswith('Your code has been rated at '):
+            scorePart = line.strip('Your code has been rated at ')
+            score = scorePart.split('/')[0]
+            try:
+                if not filename in report:
+                    report[filename] = {}
+                if not label in report[filename]:
+                    report[filename][label] = {}
+                if filename and label:
+                    report[filename][label]['score'] = score
+            except NameError:
+                print("Score of %s found, but no filename" % score)
+
+        parts = line.split(':')
+        if len(parts) != 3:
+            continue
+        try:
+            newFilename, lineNumber, rawMessage = parts
+            newFilename = newFilename.strip()
+            if not newFilename:  # Don't update filename if we didn't find one
+                continue
+            lineNumber = int(lineNumber)
+            filename = newFilename
+            rmParts = rawMessage.split(']', 1)
+            rawCode = rmParts[0].strip()
+            message = rmParts[1].strip()
+            severity = rawCode[1:2]
+            code = rawCode[2:6]
+            shortMsg = rawCode[7:]
+            msgParts = shortMsg.split(',')
+            objectName = msgParts[1].strip()
+
+            if severity == 'R':
+                refactors += 1
+            elif severity == 'W':
+                warnings += 1
+            elif severity == 'E':
+                errors += 1
+            elif severity == 'C':
+                comments += 1
+
+            if not filename in report:
+                report[filename] = {}
+
+            if not label in report[filename]:
+                report[filename][label] = {}
+            if not 'events' in report[filename][label]:
+                report[filename][label]['events'] = []
+            report[filename][label]['events'].append((lineNumber, severity, code, objectName, message))
+
+            report[filename][label]['refactors'] = refactors
+            report[filename][label]['warnings'] = warnings
+            report[filename][label]['errors'] = errors
+            report[filename][label]['comments'] = comments
+
+        except ValueError:
+            continue
+
+with open('pylintReport.json', 'w') as reportFile:
+    json.dump(report, reportFile, indent=2)
+    reportFile.write('\n')
+
+
+
+
+
+

--- a/ContainerScripts/AnalyzePyFuture.py
+++ b/ContainerScripts/AnalyzePyFuture.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+
+from __future__ import print_function, division
+
+import os
+
+with open('addedFiles.txt', 'r') as addedFiles:
+    for fileName in addedFiles:
+        fileName = fileName.strip()
+        if fileName.endswith('__init__.py'):
+            continue
+        with open(fileName, 'r') as pyFile:
+            pyLines = pyFile.readlines()
+            if fileName.endswith('.py') or 'python' in  pyLines[0]:
+                foundDivision = False
+                for line in pyLines:
+                    if '__future__' in line and 'division' in line:
+                        foundDivision = True
+                if not foundDivision:
+                    print ("* New file %s does not use python 3 division. Please add `from __future__ import division`.\n" % fileName)

--- a/ContainerScripts/CompareTests.py
+++ b/ContainerScripts/CompareTests.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import glob
+import os
+import sys
+
+try:
+    from github import Github
+except ImportError:
+    # DMWM-WMCore-UnitTests and DMWM-WMCorePy3-UnitTests don't really push anything!
+    Github = None
+
+import xunitparser
+
+testResults = {}
+
+unstableTests = []
+
+try:
+    with open('code/test/etc/UnstableTests.txt') as unstableFile:
+        for line in unstableFile:
+            unstableTests.append(line.strip())
+except:
+    print("Was not able to open list of unstable tests")
+
+# Parse all the various nose xunit test reports looking for changes
+filePattern = '*/nosetestspy3-*.xml'
+if len(sys.argv) == 2:
+    filePattern = "*/%s-*.xml" % sys.argv[1]
+for kind, directory in [('base', './MasterUnitTests/'), ('test', './LatestUnitTests/')]:
+    for xunitFile in glob.iglob(directory + filePattern):
+
+        ts, tr = xunitparser.parse(open(xunitFile))
+        for tc in ts:
+            testName = '%s:%s' % (tc.classname, tc.methodname)
+            if testName in testResults:
+                testResults[testName].update({kind: tc.result})
+            else:
+                testResults[testName] = {kind: tc.result}
+
+# Generate a Github report of any changes found
+
+issueID, mode = None, None
+
+if 'ghprbPullId' in os.environ:
+    issueID = os.environ['ghprbPullId']
+    mode = 'PR'
+elif 'TargetIssueID' in os.environ:
+    issueID = os.environ['TargetIssueID']
+    mode = 'Daily'
+
+print("Comparing tests for issueID: {} in mode: {}".format(issueID, mode))
+
+message = 'Unit test changes for pull request %s:\n' % issueID
+if mode == 'Daily':
+    message = 'Unit test changes for most recent test of master branch:\n'
+
+changed = False
+stableChanged = False
+failed = False
+errorConditions = ['error', 'failure']
+
+for testName, testResult in sorted(testResults.items()):
+    if 'base' in testResult and 'test' in testResult and testName in unstableTests:
+        if testResult['base'] != testResult['test']:
+            changed = True
+            message += "* %s (unstable) changed from %s to %s\n" % (testName, testResult['base'], testResult['test'])
+    elif 'base' in testResult and 'test' in testResult:
+        if testResult['base'] != testResult['test']:
+            changed = True
+            stableChanged = True
+            message += "* %s changed from %s to %s\n" % (testName, testResult['base'], testResult['test'])
+            if testResult['test'] in errorConditions:
+                failed = True
+    elif 'test' in testResult:
+        changed = True
+        stableChanged = True
+        message += "* %s was added. Status is %s\n" % (testName, testResult['test'])
+        if testResult['test'] in errorConditions:
+            failed = True
+    elif 'base' in testResult:
+        changed = True
+        stableChanged = True
+        message += "* %s was deleted. Prior status was %s\n" % (testName, testResult['base'])
+if failed:
+    message += '\n\nPreviously working unit tests have failed!\n'
+
+if mode == 'Daily':
+    # Alan on 25/may/2021: then there is nothing else to be done
+    print(message)
+    sys.exit(0)
+
+gh = Github(os.environ['DMWMBOT_TOKEN'])
+codeRepo = os.environ.get('CODE_REPO', 'WMCore')
+repoName = '%s/%s' % (os.environ['WMCORE_REPO'], codeRepo)
+
+issue = gh.get_repo(repoName).get_issue(int(issueID))
+
+if not changed and mode == 'Daily':
+    message = "No changes to unit tests for latest build\n"
+elif not changed:
+    message = "No changes to unit tests for pull request %s\n" % issueID
+
+if mode == 'Daily' and stableChanged:
+    issue.create_comment('%s' % message)
+elif mode != 'Daily':
+    issue.create_comment('%s' % message)
+
+if failed:
+    print('Testing of python code. DMWM-FAIL-UNIT')
+else:
+    print('Testing of python code. DMWM-SUCCEED-UNIT')

--- a/ContainerScripts/IdentifyPythonFiles.py
+++ b/ContainerScripts/IdentifyPythonFiles.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python3
+
+from __future__ import print_function, division
+
+import os
+from optparse import OptionParser
+
+usage = "usage: %prog [options] list_of_files.txt"
+parser = OptionParser(usage)
+(options, args) = parser.parse_args()
+if len(args) != 1:
+    parser.error("You must supply a file with a list of files to check")
+
+list_of_files = args[0]
+
+with open(list_of_files, 'r') as changedFiles:
+    for fileName in changedFiles:
+        fileName = fileName.strip()
+        if not fileName:
+            continue
+        if fileName.endswith('.py'):
+            print(fileName)
+            continue
+        try:
+            with open(fileName, 'r') as pyFile:
+                pyLines = pyFile.readlines()
+                if 'python' in pyLines[0]:
+                    print(fileName)
+                    continue
+        except IOError:
+            pass

--- a/ContainerScripts/PullRequestReport.py
+++ b/ContainerScripts/PullRequestReport.py
@@ -1,0 +1,390 @@
+#! /usr/bin/env python
+'''
+PullRequestReport.py
+
+Generates a pull request report from a pylint report, pylint summary,
+nosetests summary, and pycodestyle
+
+Input files are located in the directory of script execution
+
+Environment Variables:
+    JENKINS_JINJA_TEMPLATE_PATH: Location of Jinja2 Templates
+    DMWMBOT_TOKEN: GitHub token
+    CODE_REPO: Code repository name
+    WMCORE_REPO: Project name
+    ghprbPullId (optional): PR ID from Jenkins GitHub Pull Request Builder
+    TargetIssueID (optional)
+    BUILD_URL: Jenkins build URL; for report location
+
+Input Files:
+    pylintpy3Report.json: pylint report
+    pep8py3.txt: pycodestyle report
+    UnstableTests.txt: unstable unittests
+    MasterUnitTests/*/nosetestspy3-*.xml: Baseline unittest results
+    LatestUnitTests/*/nosetestspy3-*.xml: PR unittest results
+
+Output Files:
+    artifacts/PullReqequestReport.html
+'''
+
+from __future__ import print_function
+
+from collections import defaultdict
+import glob
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+
+import jinja2
+from jinja2.exceptions import TemplateNotFound
+import xunitparser
+from github import Github
+
+pylintReportFile = 'pylint.jinja'
+pylintSummaryFile = 'pylintSummary.jinja'
+unitTestSummaryFile = 'unitTestReport.jinja'
+pycodestyleReportFile = 'pycodestyle.jinja'
+
+okWarnings = ['0511', '0703', '0613']
+
+summaryMessage = ''
+longMessage = ''
+reportOn = {}
+failed = False
+
+
+def buildPylintReport(templateEnv, fileName="pylintpy3Report.json"):
+    """
+    Parse the Pylint reports
+
+    :param templateEnv: string with the Jinja2 template name
+    :param fileName: string with the file name of the report to be parsed
+
+    :returns: failedPylintPy3, pylintSummaryHTMLPy3, pylintReportPy3, pylintSummaryPy3
+    """
+    pyName = "Python3"
+    print(f"Evaluating pylint report for file: {fileName}")
+    try:
+        with open(f'LatestPylint/{fileName}', 'r') as reportFile:
+            report = json.load(reportFile)
+    except IOError:
+        print(f"File {fileName} not found.")
+        return False, None, None, None
+
+    pylintReportTemplate = templateEnv.get_template(pylintReportFile)
+    pylintSummaryTemplate = templateEnv.get_template(pylintSummaryFile)
+
+    # Process the template to produce our final text.
+    pylintReport = pylintReportTemplate.render({'report': report, 'okWarnings': okWarnings})
+    pylintSummaryHTML = pylintSummaryTemplate.render({'whichPython': pyName, 'report': report,
+                                                      'filenames': sorted(report.keys())})
+
+    # Figure out if pylint failed
+    failed = False
+    failures = 0
+    warnings = 0
+    comments = 0
+    for filename in report.keys():
+        if 'test' in report[filename]:
+            for event in report[filename]['test']['events']:
+                if event[1] in ['W', 'E'] and event[2] not in okWarnings:
+                    failed = True
+                    failures += 1
+                elif event[1] in ['W', 'E']:
+                    warnings += 1
+                else:
+                    comments += 1
+            if report[filename]['test'].get('score', None):
+                if float(report[filename]['test']['score']) < 9 and (float(report[filename]['test']['score']) <
+                                                                     float(report[filename]['base'].get('score', 0))):
+                    failed = True
+                elif float(report[filename]['test']['score']) < 8:
+                    failed = True
+
+    pylintSummary = {'failures': failures, 'warnings': warnings, 'comments': comments}
+    return failed, pylintSummaryHTML, pylintReport, pylintSummary
+
+
+def buildPyCodeStyleReport(templateEnv, inputFileName="pep8py3.txt"):
+    """
+    Build the report for pycodestyle (also known as pep8)
+
+    :param templateEnv: string with the Jinja2 template name
+    :param inputFileName: string with the file name of the report to be parsed
+
+    :returns: bool failedPycodestyle, str pycodestyleReport html, dict pycodestyleSummary
+    """
+
+    print(f"Evaluating pep8 style report for file: {inputFileName}")
+
+    errors = defaultdict(list)
+    pycodestyleReportHTML = None
+    pycodestyleSummary = {'comments': 0}
+
+    try:
+        with open(f'LatestPylint/{inputFileName}', 'r') as reportFile:
+            for line in reportFile:
+                pycodestyleSummary['comments'] += 1
+                fileName, line, error = line.split(':', 2)
+                error = error.lstrip().lstrip('[')
+                errorCode, message = error.split('] ', 1)
+                errors[fileName].append((line, errorCode, message))
+        pycodestyleReportTemplate = templateEnv.get_template(pycodestyleReportFile)
+        pycodestyleReportHTML = pycodestyleReportTemplate.render({'report': errors})
+    except IOError:
+        print(f"File {inputFileName} not found.")
+    except TemplateNotFound:
+        print(f"Template {pycodestyleReportFile} not found")
+    except Exception:
+        print("Was not able to open or parse pycodestyle tests")
+        traceback.print_exc()
+
+    return False, pycodestyleReportHTML, pycodestyleSummary
+
+def buildUnitTestReport(templateEnv, pyName="Python3"):
+    """
+    Builds the python3 unit test report
+
+    :param templateEnv: string with the name of the jinja template
+    :param pyName: string with either a Python2 or Python3 value
+
+    :returns: py3FailedUnitTests, py3UnitTestSummaryHTML, py3UnitTestSummary
+    """
+    if pyName not in ("Python2", "Python3"):
+        print("Invalid python name argument!")
+        raise RuntimeError()
+
+    print(f"Evaluating base/test {pyName} unit tests report files")
+    unstableTests = []
+    testResults = {}
+
+    try:
+        with open('UnstableTests.txt', 'r') as unstableFile:
+            for line in unstableFile:
+                unstableTests.append(line.strip())
+    except:
+        print("Was not able to open list of unstable tests")
+
+    filePattern = '*/nosetestspy3-*.xml'
+    for kind, directory in [('base', './MasterUnitTests/'), ('test', './LatestUnitTests/')]:
+        print("Scanning directory %s" % directory)
+        for xunitFile in glob.iglob(directory + filePattern):
+            print("Opening file %s" % xunitFile)
+            with open(xunitFile, 'r') as xf:
+                ts, tr = xunitparser.parse(xf)
+                for tc in ts:
+                    testName = '%s:%s' % (tc.classname, tc.methodname)
+                    if testName in testResults:
+                        testResults[testName].update({kind: tc.result})
+                    else:
+                        testResults[testName] = {kind: tc.result}
+    if not testResults:
+        print("No unit test results found!")
+        raise RuntimeError()
+
+    failed = False
+    errorConditions = ['error', 'failure']
+
+    newFailures = []
+    unstableChanges = []
+    okChanges = []
+    added = []
+    deleted = []
+
+    for testName, testResult in sorted(testResults.items()):
+        oldStatus = testResult.get('base', None)
+        newStatus = testResult.get('test', None)
+        if oldStatus and newStatus and testName in unstableTests:
+            if oldStatus != newStatus:
+                unstableChanges.append({'name': testName, 'new': newStatus, 'old': oldStatus})
+        elif oldStatus and newStatus:
+            if oldStatus != newStatus:
+                if newStatus in errorConditions:
+                    failed = True
+                    newFailures.append({'name': testName, 'new': newStatus, 'old': oldStatus})
+                else:
+                    okChanges.append({'name': testName, 'new': newStatus, 'old': oldStatus})
+        elif newStatus:
+            added.append({'name': testName, 'new': newStatus, 'old': oldStatus})
+            if newStatus in errorConditions:
+                failed = True
+        elif oldStatus:
+            deleted.append({'name': testName, 'new': newStatus, 'old': oldStatus})
+
+    unitTestSummaryTemplate = templateEnv.get_template(unitTestSummaryFile)
+    unitTestSummaryHTML = unitTestSummaryTemplate.render({'whichPython': pyName,
+                                                          'newFailures': newFailures,
+                                                          'added': added,
+                                                          'deleted': deleted,
+                                                          'unstableChanges': unstableChanges,
+                                                          'okChanges': okChanges,
+                                                          'errorConditions': errorConditions,
+                                                          })
+
+    unitTestSummary = {'newFailures': len(newFailures), 'added': len(added), 'deleted': len(deleted),
+                       'okChanges': len(okChanges), 'unstableChanges': len(unstableChanges)}
+    print(f"{pyName} Unit Test summary {unitTestSummary}")
+
+    return failed, unitTestSummaryHTML, unitTestSummary
+
+
+def reportToGithub(py3UnitTestSummary,
+                   py3FailedUnitTests,
+                   pylintSummaryPy3,
+                   failedPylintPy3,
+                   pycodestyleSummary):
+    """
+    Builds Report and GitHub Issue message
+    """
+    # Build GitHub Jenkins Results
+    try:
+        gh = Github(os.environ['DMWMBOT_TOKEN'])
+    except KeyError:
+        print('DMWMBOT_TOKEN not defined. Not updating PR')
+        return
+    codeRepo = os.environ.get('CODE_REPO', 'WMCore')
+    teamName = os.environ.get('WMCORE_REPO', 'dmwm')
+    repoName = '%s/%s' % (teamName, codeRepo)
+
+    issueID = None
+
+    if 'ghprbPullId' in os.environ:
+        issueID = os.environ['ghprbPullId']
+        mode = 'PR'
+    elif 'TargetIssueID' in os.environ:
+        issueID = os.environ['TargetIssueID']
+        mode = 'Daily'
+
+    repo = gh.get_repo(repoName)
+    issue = repo.get_issue(int(issueID))
+    reportURL = os.environ['BUILD_URL'].replace('jenkins/job',
+                                                'jenkins/view/All/job') + 'artifact/artifacts/PullRequestReport.html'
+
+    statusMap = {False: {'ghStatus': 'success', 'readStatus': 'succeeded'},
+                 True: {'ghStatus': 'failure', 'readStatus': 'failed'}, }
+
+    message = 'Jenkins results:\n'
+
+    if py3UnitTestSummary:  # Most of the repositories do not yet have python3 unit tests
+        message += (
+            f' * Python3 Unit tests: '
+            f'{statusMap[py3FailedUnitTests]["readStatus"]}\n'
+        )
+        if failures := py3UnitTestSummary['newFailures']:
+            message += f'   * {failures} new failures\n'
+        if deleted := py3UnitTestSummary['deleted']:
+            message += f'   * {deleted} tests deleted\n'
+        if okChanges := py3UnitTestSummary['okChanges']:
+            message += f'   * {okChanges} tests no longer failing\n'
+        if added := py3UnitTestSummary['added']:
+            message += f'   * {added} tests added\n'
+        if unstable := py3UnitTestSummary['unstableChanges']:
+            message += f'   * {unstable} changes in unstable tests\n'
+
+    if pylintSummaryPy3:
+        message += (
+            f' * Python3 Pylint check: '
+            f'{statusMap[failedPylintPy3]["readStatus"]}\n'
+        )
+        if pylintFails := pylintSummaryPy3['failures']:
+            message += (
+                f'   * {pylintFails} warnings and errors that must be fixed\n'
+            )
+        if warnings := pylintSummaryPy3['warnings']:
+            message += (
+                f'   * {warnings} warnings\n'
+            )
+        if comments := pylintSummaryPy3['comments']:
+            message += (
+                f'   * {comments} comments to review\n'
+            )
+
+    message += (
+        f' * Pycodestyle check: '
+        f'{statusMap[failedPycodestyle]["readStatus"]}\n'
+    )
+    if comments := pycodestyleSummary['comments']:
+        message += f'   * {comments} comments to review\n'
+
+    message += f"\nDetails at {reportURL}\n"
+
+    # GitHub PRs and Issues share the same number pool,
+    # so there won't be a PR with the same number as an issue
+
+    status = issue.create_comment(message)
+
+    timeNow = time.strftime("%d %b %Y %H:%M GMT")
+    lastCommit = repo.get_pull(int(issueID)).get_commits().get_page(0)[-1]
+
+    if pylintSummaryPy3:
+        lastCommit.create_status(
+            state=statusMap[failedPylintPy3]['ghStatus'],
+            target_url=reportURL + '#pylintpy3',
+            description='Finished at %s' % timeNow, context='Py3 Pylint'
+        )
+    if py3UnitTestSummary:
+        lastCommit.create_status(
+            state=statusMap[py3FailedUnitTests]['ghStatus'],
+            target_url=reportURL + '#unittestspy3',
+            description='Finished at %s' % timeNow, context='Py3 Unit tests'
+        )
+
+
+if __name__ == '__main__':
+    ### main code
+    # load jinja templates
+    try:
+        templatePathEnv = os.environ["JENKINS_JINJA_TEMPLATE_PATH"]
+        templatePath = Path(templatePathEnv)
+        if not templatePath.exists():
+            raise FileNotFoundError(f'{templatePath} not found')
+        if not templatePath.is_dir():
+            raise NotADirectoryError(f'{templatePath} is not a directory')
+    except KeyError:
+        print('JENKINS_JINJA_TEMPLATE_PATH not defined')
+        raise
+
+    templateLoader = jinja2.FileSystemLoader(searchpath=templatePath)
+    templateEnv = jinja2.Environment(loader=templateLoader, trim_blocks=True, lstrip_blocks=True)
+
+    # Build Python3 Pylint report from jenkins artifacts (NOTE: most of the projects don't have it yet)
+    failedPylintPy3, pylintSummaryHTMLPy3, pylintReportPy3, pylintSummaryPy3 = buildPylintReport(templateEnv,
+                                                                                                 "pylintpy3Report.json")
+    # Build pycodestyleReport
+    try:
+        failedPycodestyle, pycodestyleReport, pycodestyleSummary = buildPyCodeStyleReport(templateEnv, "pep8py3.txt")
+    except:
+        # then fallback to pep8.txt file instead
+        failedPycodestyle, pycodestyleReport, pycodestyleSummary = buildPyCodeStyleReport(templateEnv)
+
+    # Now try to create the Python3 based unit tests
+    try:
+        py3FailedUnitTests, py3UnitTestSummaryHTML, py3UnitTestSummary = buildUnitTestReport(templateEnv, pyName="Python3")
+    except (IOError, RuntimeError):
+        py3FailedUnitTests, py3UnitTestSummaryHTML, py3UnitTestSummary = 0, '', {}
+
+    with open('artifacts/PullRequestReport.html', 'w') as html:
+        if py3UnitTestSummary:
+            html.write(py3UnitTestSummaryHTML)
+        if pylintSummaryPy3:
+            html.write(pylintSummaryHTMLPy3)
+            html.write(pylintReportPy3)
+        if pycodestyleReport:
+            html.write(pycodestyleReport)
+
+    reportToGithub(py3UnitTestSummary, py3FailedUnitTests, pylintSummaryPy3, failedPylintPy3, pycodestyleSummary)
+
+    if pylintSummaryPy3:
+        if failedPylintPy3:
+            print('Testing of python code. DMWM-FAIL-PYLINTPY3')
+        else:
+            print('Testing of python code. DMWM-SUCCEED-PYLINTPY3')
+
+    if py3UnitTestSummary:
+        if py3FailedUnitTests:
+            print('Testing of python code. DMWM-FAIL-PY3-UNIT')
+        else:
+            print('Testing of python code. DMWM-SUCCEED-PY3-UNIT')

--- a/ContainerScripts/PullRequestTestBegin.py
+++ b/ContainerScripts/PullRequestTestBegin.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+
+import os
+import sys
+import time
+
+from github import Github
+
+
+try:
+    gh = Github(os.environ['DMWMBOT_TOKEN'])
+except KeyError:
+    print('DMWMBOT_TOKEN not defined. Not updating PR')
+
+codeRepo = os.environ.get('CODE_REPO', 'WMCore')
+teamName = os.environ.get('WMCORE_REPO', 'dmwm')
+repoName = f'{teamName}/{codeRepo}'
+
+issueID = None
+
+if 'ghprbPullId' in os.environ:
+    issueID = os.environ['ghprbPullId']
+    mode = 'PR'
+elif 'TargetIssueID' in os.environ:
+    issueID = os.environ['TargetIssueID']
+    mode = 'Daily'
+
+print(f"Looking for {repoName} issue {issueID}")
+
+repo = gh.get_repo(repoName)
+issue = repo.get_issue(int(issueID))
+reportURL = os.environ['BUILD_URL']
+
+lastCommit = repo.get_pull(int(issueID)).get_commits().get_page(0)[-1]
+
+lastCommit.create_status(
+    state='pending',
+    target_url=reportURL,
+    description=f'Tests started at {time.strftime("%d %b %Y %H:%M GMT")}'
+)

--- a/ContainerScripts/deployWMAgent.sh
+++ b/ContainerScripts/deployWMAgent.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+. ./cms-bot/DMWM/setup-secrets.sh
+. ./cms-bot/DMWM/update-deployment.sh
+. ./cms-bot/DMWM/latest-dmwm-versions.sh
+
+if [ -z "$WMAGENT_VERSION" ]; then
+  export WMAGENT_VERSION=$WMAGENT_LATEST
+fi
+
+. ./cms-bot/DMWM/deploy-wmagent.sh
+

--- a/ContainerScripts/deploy_unittest_py3.sh
+++ b/ContainerScripts/deploy_unittest_py3.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+###
+# usage
+# deploy current version of wmagent external library and use the dmwm/master WMCore code to set up unittest
+# sh ./deploy_unittest.sh
+#
+# Also optional values can be specified. -v deploy agent version, -r git repository for code to test,
+# -b branch name of the repository.
+# following
+# i.e) sh ./deploy_unittest.sh -v 1.0.6 -r ticonaan -v 1.0.5_wmagent
+#
+# for running the test check the tutorial, https://github.com/dmwm/WMCore/wiki/Setup-wmcore-unittest
+###
+DMWM_ARCH=slc7_amd64_gcc630
+VERSION=$(curl -s "http://cmsrep.cern.ch/cgi-bin/repos/comp/$DMWM_ARCH?C=M;O=D" | grep -oP "(?<=>cms\+wmagentpy3-dev\+).*(?=-1-1)" | head -1)
+
+REPOSITORY=dmwm
+BRANCH=
+UPDATE=false
+
+deploy_agent() {
+
+    git clone https://github.com/dmwm/deployment.git
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/init.sh > init.sh
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/env_unittest_py3.sh > env_unittest_py3.sh
+    curl -s https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/WMAgent_unittest.secrets > WMAgent_unittest.secrets
+    source ./init.sh
+    # set -e
+    for step in prep sw post; do
+        echo -e "\n*** Deploying WMAgent py3: running $step step ***"
+        $PWD/deployment/Deploy -R wmagentpy3-dev@$1 -r comp=comp -t $1 -A $DMWM_ARCH -s $step $INSTALL_DIR wmagentpy3/devtools
+        if [ $? -ne 0 ]; then
+            ls $INSTALL_DIR
+            cat $INSTALL_DIR/.deploy/*-$step.log
+            exit 1
+        fi
+    done
+    # set +e
+}
+
+setup_test_src() {
+    (
+     mkdir $TEST_DIR;
+     cd $TEST_DIR;
+     git clone https://github.com/$1/WMCore.git;
+     cd WMCore
+     # if branch is set check out the branch
+     if [ -n $2 ]
+     then
+        git checkout $2
+     fi;
+    )
+}
+
+update_src() {
+    (
+    rm -rf $TEST_DIR;
+    setup_test_src $1 $2
+    )
+}
+
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        -v)  VERSION=$2; shift;;
+        -r)  REPOSITORY=$2; shift;;
+        -b)  BRANCH=$2; shift;;
+        -u)  UPDATE=true;;
+        *)  break;;	# terminate while loop
+    esac
+    shift
+done
+
+if [ $UPDATE = "true" ]
+then
+    source ./env_unittest_py3.sh
+    update_src $REPOSITORY $BRANCH
+else
+    echo "--- deploying agent $VERSION with local user $USER"
+    # deploy agent
+    deploy_agent $VERSION
+    echo "--- updating agent source repository $REPOSITORY, branch $BRANCH"
+    # checkout test source
+    setup_test_src $REPOSITORY $BRANCH
+
+    # swap the source code from deployed one test source
+    source ./env_unittest_py3.sh
+    echo "--- starting services"
+    $manage start-services
+
+    echo "--- creating MariaDB database"
+    mysql -u $USER --socket=$INSTALL_DIR/current/install/mysql/logs/mysql.sock --execute "create database wmcore_unittest"
+fi

--- a/ContainerScripts/fixCertificates.sh
+++ b/ContainerScripts/fixCertificates.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -x
+
+# Certificates are either not readable by the container or have the wrong permissions
+
+cp orig-certs/servicecert.pem.orig certs/servicecert.pem
+cp orig-certs/servicekey.pem.orig certs/servicekey.pem
+chmod 600 certs/servicecert.pem
+chmod 400 certs/servicekey.pem

--- a/ContainerScripts/installCMSBot.sh
+++ b/ContainerScripts/installCMSBot.sh
@@ -1,0 +1,9 @@
+git clone https://github.com/cms-sw/cms-bot
+pushd cms-bot/
+
+wget https://pypi.python.org/packages/source/r/requests/requests-2.3.0.tar.gz#md5=7449ffdc8ec9ac37bbcd286003c80f00
+tar -xvf requests-2.3.0.tar.gz
+rm -rf requests || true
+mv requests-2.3.0/requests/ requests
+
+popd

--- a/ContainerScripts/installWMCore.sh
+++ b/ContainerScripts/installWMCore.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# Download the script to install everything
+curl https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/deploy_unittest.sh > /home/dmwm/ContainerScripts/deploy_unittest.sh
+chmod +x /home/dmwm/ContainerScripts/deploy_unittest.sh
+sh /home/dmwm/ContainerScripts/deploy_unittest.sh
+
+echo "export PYTHONPATH=/home/dmwm/wmcore_unittest/WMCore/src/python:\$PYTHONPATH" >> ./env_unittest.sh
+# Shut down services so the docker container doesn't have stale PID & socket files
+source ./env_unittest.sh
+$manage stop-services
+

--- a/ContainerScripts/installWMCorePy3.sh
+++ b/ContainerScripts/installWMCorePy3.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# Download the script to install everything
+curl https://raw.githubusercontent.com/dmwm/WMCore/master/test/deploy/deploy_unittest_py3.sh > /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+chmod +x /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+sh /home/dmwm/ContainerScripts/deploy_unittest_py3.sh
+
+echo "export PYTHONPATH=/home/dmwm/wmcore_unittest/WMCore/src/python:\$PYTHONPATH" >> ./env_unittest_py3.sh
+# Shut down services so the docker container doesn't have stale PID & socket files
+source ./env_unittest_py3.sh
+$manage stop-services
+

--- a/ContainerScripts/pyfutureTest.sh
+++ b/ContainerScripts/pyfutureTest.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
+  echo "Not all necessary environment variables set: ghprbPullId, ghprbTargetBranch"
+  exit 1
+fi
+
+echo "$(TZ=GMT date): running pyfutureTest.sh script"
+source ./env_unittest.sh
+
+pushd wmcore_unittest/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:${PYTHONPATH}
+
+git config remote.origin.url https://github.com/dmwm/WMCore.git
+git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+git checkout -f ${COMMIT}
+
+echo "$(TZ=GMT date): figuring out what are the files that changed"
+# Find all the changed files and filter python-only
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
+git diff-tree --name-status  -r ${ghprbTargetBranch}..${COMMIT} | egrep "^A" | cut -f 2 > allAddedFiles.txt
+${HOME}/ContainerScripts/IdentifyPythonFiles.py allAddedFiles.txt > addedFiles.txt
+rm -f allChangedFiles.txt allAddedFiles.txt
+
+echo "$(TZ=GMT date): running futurize 1st stage and some fixers"
+while read name; do
+  futurize -1 $name >> test.patch
+  futurize -f execfile -f filter -f raw_input $name >> test.patch || true
+  futurize -f idioms $name  >> idioms.patch || true
+done <changedFiles.txt
+
+# Get added files and analyze future imports
+echo "$(TZ=GMT date): running AnalyzePyFuture.py script"
+${HOME}/ContainerScripts/AnalyzePyFuture.py > added.message
+
+cp test.patch idioms.patch added.message ${HOME}/artifacts/
+echo "$(TZ=GMT date): done with all tests and copying files over to artifacts!"
+popd

--- a/ContainerScripts/tagLatestWMCore.sh
+++ b/ContainerScripts/tagLatestWMCore.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ -z "$DMWMBOT_TOKEN" -o -z "$WMCORE_REPO" -o -z "$CODE_REPO" -o -z "$TAG_PREFIX" ]; then
+  echo "Not all necessary environment variables set: DMWMBOT_TOKEN, WMCORE_REPO, CODE_REPO"
+  exit 1
+fi
+  
+pushd $WORKSPACE/WMCore
+
+set +x
+git remote set-url origin https://${DMWMBOT_TOKEN}:x-oauth-basic@github.com/${WMCORE_REPO}/${CODE_REPO}
+set -x
+
+git checkout master
+git pull
+
+# Create a new tag and push it
+export TAG=${TAG_PREFIX}_`date "+%Y%m%d%H%M%S"`
+git tag ${TAG}
+echo Will add tag: $TAG
+#git push origin ${TAG}
+
+# Deletes tags from previous days
+export VALID_TAGS=`date "+JENKINS_%Y%m%d"`
+git tag -d `git tag | grep JENKINS`
+git fetch --tags 
+#git push --delete origin `git tag | grep JENKINS | grep -Ev ${VALID_TAGS}` || true
+
+popd

--- a/ContainerScripts/updateGit.sh
+++ b/ContainerScripts/updateGit.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+pushd /home/dmwm/wmcore_unittest/WMCore/
+git pull
+git fetch --quiet --tags  https://github.com/dmwm/WMCore.git "+refs/heads/*:refs/remotes/origin/*"
+git config remote.origin.url https://github.com/dmwm/WMCore.git
+git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git fetch --quiet --tags  https://github.com/dmwm/WMCore.git "+refs/pull/*:refs/remotes/origin/pr/*"
+
+
+
+popd

--- a/TestScripts/env_unittest.sh
+++ b/TestScripts/env_unittest.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+export USER=`whoami`
+export BASE_DIR=$PWD
+export TEST_DIR=$BASE_DIR/wmcore_unittest
+export TEST_SRC=$TEST_DIR/WMCore/src
+export TEST_SRC_PYTHON=$TEST_SRC/python
+export INSTALL_DIR=$BASE_DIR/unittestdeploy/wmagent
+export ADMIN_DIR=/data/admin/wmagent
+export CERT_DIR=/data/certs
+
+#export ORG_SRC_PYTHON=$INSTALL_DIR/current/apps/wmagentpy3/lib/python3.8/site-packages/
+#export ORG_SRC_OTHER=$INSTALL_DIR/current/apps/wmagentpy3/data
+#export DBSOCK=$INSTALL_DIR/current/install/mysql/logs/mysql.sock
+
+# TODO: Somewhat redundant in TestScripts/test-wmcorepy3.sh
+export DATABASE=mysql://${MDB_USER}:${MDB_PASS}@127.0.0.1/${MDB_UNITTEST_DB}
+export COUCHURL=http://unittestagent:passwd@localhost:6994
+export DIALECT=MySQL
+
+#rm -rf $ORG_SRC_PYTHON/*
+
+# ln -s $TEST_SRC_PYTHON/WMCore/ $ORG_SRC_PYTHON
+# ln -s $TEST_SRC_PYTHON/WMComponent/ $ORG_SRC_PYTHON
+# ln -s $TEST_SRC_PYTHON/PSetTweaks/ $ORG_SRC_PYTHON
+# ln -s $TEST_SRC_PYTHON/WMQuality/ $ORG_SRC_PYTHON
+# ln -s $TEST_SRC_PYTHON/Utils/ $ORG_SRC_PYTHON
+
+# rm -rf $ORG_SRC_OTHER/*
+
+# ln -s $TEST_SRC/couchapps/ $ORG_SRC_OTHER
+# ln -s $TEST_SRC/css/ $ORG_SRC_OTHER
+# ln -s $TEST_SRC/html/ $ORG_SRC_OTHER
+# ln -s $TEST_SRC/javascript/ $ORG_SRC_OTHER
+# ln -s $TEST_SRC/template/ $ORG_SRC_OTHER
+
+export WMAGENT_SECRETS_LOCATION=$ADMIN_DIR/WMAgent.secrets
+export X509_HOST_CERT=$CERT_DIR/servicecert.pem
+export X509_HOST_KEY=$CERT_DIR/servicekey.pem
+export X509_USER_CERT=$CERT_DIR/servicecert.pem
+export X509_USER_KEY=$CERT_DIR/servicekey.pem
+
+# export install=$INSTALL_DIR/current/install/wmagentpy3
+# export config=$INSTALL_DIR/current/config/wmagentpy3
+# export manage=$config/manage
+
+# source $INSTALL_DIR/current/apps/wmagentpy3/etc/profile.d/init.sh
+# source $INSTALL_DIR/current/apps/wmcorepy3-devtools/etc/profile.d/init.sh
+
+### some Rucio setup needed for jenkins and docker unit tests
+# fetch the values defined in the secrets file and update rucio.cfg file
+export RUCIO_HOME=$BASE_DIR # TODO: Change to specific rucio directory
+MATCH_RUCIO_HOST=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_HOST | sed s/RUCIO_HOST=//`
+MATCH_RUCIO_AUTH=`cat $WMAGENT_SECRETS_LOCATION | grep RUCIO_AUTH | sed s/RUCIO_AUTH=//`
+sed "s+^rucio_host.*+rucio_host = $MATCH_RUCIO_HOST+" $RUCIO_HOME/etc/rucio.cfg-temp > $RUCIO_HOME/etc/rucio.cfg
+sed "s+^auth_host.*+auth_host = $MATCH_RUCIO_AUTH+" $RUCIO_HOME/etc/rucio.cfg-temp > $RUCIO_HOME/etc/rucio.cfg
+echo "Updated RUCIO_HOME file under: $RUCIO_HOME"
+
+export PYTHONPATH=/home/cmsbld/WMCore/test/python:$PYTHONPATH
+export PYTHONPATH=/home/cmsbld/WMCore/src/python:$PYTHONPATH

--- a/TestScripts/pylint3kWMCore.sh
+++ b/TestScripts/pylint3kWMCore.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Run pylint over the entire WMCore code base for compatibility checks
+
+source ./env_unittest.sh
+pushd wmcore_unittest/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:$PYTHONPATH
+
+git checkout master
+git pull origin
+
+# Run the python3 compatibility checkers in python
+echo "Printing Pylint version"
+pylint --version
+
+# Disable: [W1618(no-absolute-import), ] import missing `from __future__ import absolute_import`
+pylint --py3k -j 2 -f parseable -d W1618 src/python/* test/python/*

--- a/TestScripts/pylintPRTest.sh
+++ b/TestScripts/pylintPRTest.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+WORKDIR=/home/cmsbld
+
+if [ -z "$ghprbPullId" -o -z "$ghprbTargetBranch" ]; then
+  echo "Not all necessary environment variables set: ghprbPullId, ghprbTargetBranch"
+  exit 1
+fi
+
+echo "Executing Pylint for PR ID $ghprbPullId and target branch $ghprbTargetBranch"
+
+# Setup the environment
+echo "Sourcing a python3 unittest environment"
+source $WORKDIR/TestScripts/env_unittest.sh
+JSON_FILENAME=pylintpy3Report.json
+PEP8_FILENAME=pep8py3.txt
+
+pushd $WORKDIR/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:$PYTHONPATH
+
+# Figure out the one commit we are interested in and what happens to the repo if we were to merge it
+git config remote.origin.url https://github.com/dmwm/WMCore.git
+git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+git checkout ${ghprbTargetBranch}
+git pull
+
+# Which python files changed?
+git diff --name-only  ${ghprbTargetBranch}..${COMMIT} > allChangedFiles.txt
+$WORKDIR/ContainerScripts/IdentifyPythonFiles.py allChangedFiles.txt > changedFiles.txt
+
+echo "Printing Pylint version"
+pylint --version
+
+# Get pylint report for master
+git checkout -f $ghprbTargetBranch
+echo "{}" > pylintReport.json
+echo "*** Running Pylint on the changed files against the $ghprbTargetBranch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile standards/.pylintrc --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name > pylint.out || true
+  $WORKDIR/ContainerScripts/AggregatePylint.py base
+done <changedFiles.txt
+
+# Get pylint report for the tip of our branch
+git checkout -f $COMMIT
+echo "*** Running Pylint on the changed files against the feature branch"
+while read name; do
+  pylint --evaluation='10.0 - ((float(5 * error + warning) / statement) * 10)'  --rcfile standards/.pylintrc  --msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'  $name  > pylint.out || true
+  $WORKDIR/ContainerScripts/AggregatePylint.py test
+done <changedFiles.txt
+
+# Save the artifacts to a directory shared by the container and the node
+# update file if it's a python3 pylint job
+mv pylintReport.json ${JSON_FILENAME} || true
+cp *.json $WORKDIR/artifacts/
+
+touch NOTHING # If changedFiles.txt is empty, this will keep it from parsing the whole directory tree
+pycodestyle NOTHING `< changedFiles.txt` > ${PEP8_FILENAME}
+cp ${PEP8_FILENAME} $WORKDIR/artifacts/
+
+popd

--- a/TestScripts/pylintWMCore.sh
+++ b/TestScripts/pylintWMCore.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Run pylint and pep8 (pycodestyle) over the entire WMCore code base
+
+# Setup the environment
+if [[ -f env_unittest_py3.sh ]]
+then
+    echo "Sourcing a python3 unittest environment"
+    source env_unittest_py3.sh
+    OUT_FILENAME=pylintpy3.txt
+else
+    echo "Sourcing a python2 unittest environment"
+    source env_unittest.sh
+    OUT_FILENAME=pylint.txt
+fi
+
+pushd wmcore_unittest/WMCore
+export PYTHONPATH=`pwd`/test/python:`pwd`/src/python:$PYTHONPATH
+
+git checkout master
+git pull origin
+
+echo "Printing Pylint version"
+pylint --version
+
+# Run pylint on the whole code base
+pylint --rcfile=standards/.pylintrc -j 2 -f parseable src/python/* test/python/*
+
+# Fix pep8 which has the wrong python executable
+echo "#! /usr/bin/env python" > ../pep8
+cat `which pep8` >> ../pep8
+chmod +x ../pep8
+
+# Run PEP-8 checker but not in pylint format
+pycodestyle --format=default --exclude=test/data,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox.
+
+cp ${PEP8_FILENAME} ${HOME}/artifacts/

--- a/TestScripts/runPath.sh
+++ b/TestScripts/runPath.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+echo Running tests in path $1 
+set -x
+
+# Make sure we the certs we use are readable by us and only us 
+
+/home/dmwm/ContainerScripts/fixCertificates.sh
+
+# Start up services (Couch and MySQL)
+
+source ./env_unittest.sh
+$manage start-services
+
+cd /home/dmwm/wmcore_unittest/WMCore/
+
+# Make sure we base our tests on the latest Jenkins-tested master 
+
+/home/dmwm/ContainerScripts/updateGit.sh
+
+export LATEST_TAG=`git tag |grep JENKINS| sort | tail -1`
+if [ -z "$2" ]; then
+  export COMMIT=$LATEST_TAG
+else
+  export COMMIT=`git rev-parse "origin/pr/$3/merge^{commit}"`
+fi
+
+# First try to merge this PR into the same tag used for the baseline
+# Finally give up and just test the tip of the branch
+(git checkout $LATEST_TAG && git merge $COMMIT) ||  git checkout -f $COMMIT
+
+# Run tests and watchdog to shut it down if needed
+
+cd /home/dmwm/wmcore_unittest/WMCore/
+rm test/python/WMCore_t/REST_t/*_t.py
+/home/dmwm/cms-bot/DMWM/TestWatchdog.py &
+python setup.py test --buildBotMode=true --reallyDeleteMyDatabaseAfterEveryTest=true --testCertainPath=$1 --testTotalSlices=1 --testCurrentSlice=0
+ 
+# Save the results
+
+cp nosetests.xml /home/dmwm/artifacts/nosetests-path.xml

--- a/TestScripts/runSlice.sh
+++ b/TestScripts/runSlice.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+if [ -z "$1" -o -z "$2" ]; then
+  echo "Not all necessary environment variables set: Two parameters for slice and number of slices"
+  exit 1
+fi
+
+echo Running slice $1 of $2
+
+# Make sure we the certs we use are readable by us and only us
+
+/home/dmwm/ContainerScripts/fixCertificates.sh
+
+# Start up services (Couch and MySQL)
+
+source ./env_unittest.sh
+$manage start-services
+
+pushd /home/dmwm/wmcore_unittest/WMCore/
+
+# Make sure we base our tests on the latest Jenkins-tested master
+# sometimes GitHub has issues, so try each command twice
+
+timeout -s 9 5m git fetch --tags || timeout -s 9 5m git fetch --tags
+timeout -s 9 5m git pull || timeout -s 9 5m git fetch --tags
+export LATEST_TAG=`git tag |grep JENKINS| sort | tail -1`
+
+# Find the commit that represents the tip of the PR the latest tag
+if [ -z "$ghprbPullId" ]; then
+  export COMMIT=$LATEST_TAG
+else
+  git config remote.origin.url https://github.com/dmwm/WMCore.git
+  timeout -s 9 5m git fetch origin pull/${ghprbPullId}/merge:PR_MERGE
+  export COMMIT=`git rev-parse "PR_MERGE^{commit}"`
+fi
+
+# First try to merge this PR into the same tag used for the baseline
+# If it doesn't merge, just test the tip of the branch
+(git checkout $LATEST_TAG && git merge $COMMIT) ||  git checkout -f $COMMIT
+
+# Run tests and watchdog to shut it down if needed
+export USER=`whoami`
+/home/dmwm/cms-bot/DMWM/TestWatchdog.py &
+timeout 80m python setup.py test --buildBotMode=true --reallyDeleteMyDatabaseAfterEveryTest=true --testCertainPath=test/python --testTotalSlices=$2 --testCurrentSlice=$1
+
+# Save the results
+
+cp nosetests.xml /home/dmwm/artifacts/nosetests-$1.xml
+
+popd

--- a/TestScripts/test-wmcorepy3.sh
+++ b/TestScripts/test-wmcorepy3.sh
@@ -1,0 +1,105 @@
+#! /bin/bash -e
+
+WORKDIR=/home/cmsbld
+SCRIPTDIR=$WORKDIR/TestScripts
+CODE=$WORKDIR/WMCore
+
+pushd $WORKDIR
+
+start=`date +%s`
+
+set +x
+# load environment
+echo "Sourcing a python3 unittest environment"
+. $WORKDIR/TestScripts/env_unittest.sh
+
+# load wmagent secrets
+. /data/admin/wmagent/WMAgent.secrets
+
+# Load CMS environment from CVMFS
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+
+# This is what the production wmagent-mariadb image defines (via WMA_DATABASE) has as of 2024/07/15
+# TODO: We should either make an option in the mariadb image to define the default WMA_DATABASE or make a custom test mariadb image
+MDB_UNITTEST_DB=wmagent
+
+export DATABASE=mysql://${MDB_USER}:${MDB_PASS}@127.0.0.1/${MDB_UNITTEST_DB}
+export COUCHURL="http://${COUCH_USER}:${COUCH_PASS}@${COUCH_HOST}:${COUCH_PORT}"
+
+# ensure db exists
+# retry if fails
+
+
+for i in 1 2 3 4 5; do
+    mysql -u ${MDB_USER} -h 127.0.0.1 -p${MDB_PASS} --execute "CREATE DATABASE IF NOT EXISTS ${MDB_UNITTEST_DB}" && break
+
+    echo "Attempt $i failed. Trying again..."
+    sleep 5
+done
+
+# rucio
+export RUCIO_HOST=$RUCIO_HOST
+export RUCIO_AUTH=$RUCIO_AUTH
+set -x
+
+pushd $CODE
+
+git pull origin master
+
+# use ghprbPullId if triggered from a PR
+if [[ ! -z "${ghprbPullId}" ]]; then
+    git fetch --tags  https://github.com/dmwm/WMCore.git "+refs/heads/*:refs/remotes/origin/*"
+    git config remote.origin.url https://github.com/dmwm/WMCore.git
+    git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch --tags --quiet  https://github.com/dmwm/WMCore.git "+refs/pull/*:refs/remotes/origin/pr/*"
+    export COMMIT=`git rev-parse "origin/pr/$ghprbPullId/merge^{commit}"`
+    export LATEST_TAG=`git tag |grep JENKINS| sort | tail -1`
+
+    # First try to merge this PR into the same tag used for the baseline
+    # Next try to merge this tag onto current master
+    # Finally give up and just test the tip of the branch
+    (git checkout $LATEST_TAG && git merge $COMMIT) || (git checkout master && git merge $COMMIT) || git checkout -f $COMMIT
+fi
+
+popd
+
+### Some tweaks for the nose run (in practice, there is nothing to change in setup_test.py...)
+# working dir includes entire python source - ignore
+perl -p -i -e 's/--cover-inclusive//' $CODE/setup_test.py
+# cover branches but not external python modules
+perl -p -i -e 's/--cover-inclusive/--cover-branches/' $CODE/setup_test.py
+perl -p -i -e "s/'--cover-html',//" $CODE/setup_test.py
+
+#export NOSE_EXCLUDE='AlertGenerator'
+# timeout tests after 5 mins
+#export NOSE_PROCESSES=1
+#export NOSE_PROCESS_TIMEOUT=300
+#export NOSE_PROCESS_RESTARTWORKER=1
+
+# include FWCore.ParameterSet.Config
+
+export PYTHONPATH=/var/lib/jenkins/additional-library:$PYTHONPATH
+
+# remove old coverage data
+coverage erase
+
+# debugging python interpreters
+echo "Python version is: " && python --version || true
+echo "Python3 version is: " && python3 --version || true
+
+# run test - force success though - failure stops coverage report
+rm nosetests*.xml || true
+# FIXME Alan on 25/may/2021: ImportError: cannot import name _psutil_linux
+#python3 cms-bot/DMWM/TestWatchdog.py &
+
+python3 $CODE/setup.py test --buildBotMode=true --reallyDeleteMyDatabaseAfterEveryTest=true --testCertainPath=$CODE/test/python --testTotalSlices=$SLICES --testCurrentSlice=$SLICE || true #--testCertainPath=test/python/WMCore_t/WMBS_t || true
+mv nosetests.xml artifacts/nosetestspy3-$SLICE-$BUILD_ID.xml
+
+# Add these here as they need the same environment as the main run
+#FIXME: change so initial coverage command skips external code
+# coverage xml -i --include=$PWD/install* || true
+
+end=`date +%s`
+runtime=$((end-start))
+
+echo "Total time to test slice $SLICE: $runtime"

--- a/TestScripts/test-wmcorepy3.sh
+++ b/TestScripts/test-wmcorepy3.sh
@@ -29,11 +29,10 @@ export COUCHURL="http://${COUCH_USER}:${COUCH_PASS}@${COUCH_HOST}:${COUCH_PORT}"
 # ensure db exists
 # retry if fails
 
-
-for i in 1 2 3 4 5; do
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    echo "Attempt $i to create mariadb database..."
     mysql -u ${MDB_USER} -h 127.0.0.1 -p${MDB_PASS} --execute "CREATE DATABASE IF NOT EXISTS ${MDB_UNITTEST_DB}" && break
 
-    echo "Attempt $i failed. Trying again..."
     sleep 5
 done
 

--- a/WMCore-Aggregate-Baseline/Jenkinsfile
+++ b/WMCore-Aggregate-Baseline/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 cleanWs()
 
-                git branch: 'test-20241127-image', poll: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
+                git branch: 'fix-12187', poll: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
 
                 copyArtifacts filter: 'artifacts/nosetest*.xml',
                 fingerprintArtifacts: true,

--- a/WMCore-Aggregate-Baseline/Jenkinsfile
+++ b/WMCore-Aggregate-Baseline/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 cleanWs()
 
-                git branch: 'main', poll: false, url: 'https://github.com/dmwm/WMCore-Jenkins'
+                git branch: 'test-20241127-image', poll: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
 
                 copyArtifacts filter: 'artifacts/nosetest*.xml',
                 fingerprintArtifacts: true,

--- a/WMCore-PR-Report/Jenkinsfile
+++ b/WMCore-PR-Report/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             steps {
                 cleanWs()
 
-                git branch: 'test-20241127-image', poll: false, changelog: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
+                git branch: 'fix-12187', poll: false, changelog: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
 
                 sh '''
                 echo "$(TZ=GMT date): Job name is $JOB_NAME"

--- a/WMCore-PR-Report/Jenkinsfile
+++ b/WMCore-PR-Report/Jenkinsfile
@@ -109,7 +109,11 @@ pipeline {
         always {
             archiveArtifacts artifacts: 'artifacts/PullRequestReport.html', followSymlinks: false
 
-            junit keepTestNames: true, skipPublishingChecks: true, stdioRetention: '', testResults: 'LatestUnitTests/*/nosetests*.xml'
+            junit keepTestNames: true,
+            skipPublishingChecks: true,
+            stdioRetention: '',
+            skipMarkingBuildUnstable: true, 
+            testResults: 'LatestUnitTests/*/nosetests*.xml'
 
             cleanWs()
         }

--- a/WMCore-PR-Report/Jenkinsfile
+++ b/WMCore-PR-Report/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             steps {
                 cleanWs()
 
-                git branch: 'main', poll: false, changelog: false, url: 'https://github.com/dmwm/WMCore-Jenkins'
+                git branch: 'test-20241127-image', poll: false, changelog: false, url: 'https://github.com/d-ylee/WMCore-Jenkins'
 
                 sh '''
                 echo "$(TZ=GMT date): Job name is $JOB_NAME"

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
         stage('Run pylint tests') {
             steps {
                 sh ''' 
-                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run --quiet-pull -d $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
+                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -u $MY_ID --quiet-pull -d $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    sleep 20
                    # docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    '''

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         WMA_TAG = '2.3.3'
         COUCH_TAG = '3.2.2'
         MDB_TAG = '10.6.19'
-        WMCORE_DEV_TAG = '0.2.0'
+        WMCORE_DEV_TAG = '0.2.0-stable'
 
         TEST_SERVICE = 'wmcore-pr-pylint'
 

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -52,9 +52,9 @@ pipeline {
         stage('Run pylint tests') {
             steps {
                 sh ''' 
-                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d $TEST_SERVICE
+                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run --quiet-pull -d $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    sleep 20
-                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
+                   # docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    '''
             }
         }

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
         WMA_TAG = '2.3.3'
         COUCH_TAG = '3.2.2'
         MDB_TAG = '10.6.19'
+        WMCORE_DEV_TAG = '0.2.0'
 
         TEST_SERVICE = 'wmcore-pr-pylint'
 
@@ -38,7 +39,7 @@ pipeline {
     stages {
         stage('Setup') {
             steps {
-                git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
+                git branch: 'fix-12187', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                 sh '''
                    echo "Running WMCore-PR-pylint for ${ghprbPullId}"
                    echo "Setting up workspace directories"

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -46,13 +46,16 @@ pipeline {
                    ls $WORKSPACE
                    echo "python3 version"
                    python3 --version
+
+                   echo "Ensuring all compose services are down"
+                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE --rmi all
                    '''
             }
         }
         stage('Run pylint tests') {
             steps {
                 sh ''' 
-                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -u $MY_ID --quiet-pull -d $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
+                   docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -u $MY_ID --quiet-pull $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    sleep 20
                    # docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID $TEST_SERVICE /home/cmsbld/TestScripts/pylintPRTest.sh
                    '''

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     stages {
         stage('Setup') {
             steps {
-                git branch: 'main', url: 'https://github.com/dmwm/WMCore-Jenkins'
+                git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                 sh '''
                    echo "Running WMCore-PR-pylint for ${ghprbPullId}"
                    echo "Setting up workspace directories"
@@ -63,7 +63,7 @@ pipeline {
     post {
         always {
             sh '''
-               docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE
+               docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE --rmi all
                '''
             archiveArtifacts artifacts: 'artifacts/*.json, artifacts/pep*.txt',
                                followSymlinks: false,

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                                         retry(5) {
                                             sh ''' 
                                             echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                            docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
+                                            docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
                                             '''
 
                                             sleep(5)

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                         steps {
                             throttle(['DMWM-services']) {
                                 node( 'cms-dmwm-el9' ) {
-                                    git branch: 'main', url: 'https://github.com/dmwm/WMCore-Jenkins'
+                                    git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                                     sh '''
                                     echo "$(TZ=GMT date): Job name is $JOB_NAME"
 
@@ -58,9 +58,9 @@ pipeline {
                                     docker compose version
 
                                     echo "Make sure all containers are stopped"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down mariadb
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down couchdb
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE --rmi all
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down mariadb --rmi all
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down couchdb --rmi all
 
                                     echo "Docker ps:"
                                     docker ps
@@ -78,7 +78,7 @@ pipeline {
                                     $WORKSPACE/WMCore-Test-Base/setup-env.sh
 
                                     #echo "Make sure all containers are stopped"
-                                    #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE
+                                    #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE --rmi all
 
                                     echo "User: $USER"
                                     whoami
@@ -101,7 +101,7 @@ pipeline {
                                     }
 
                                     sh '''
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down --rmi all
                                     '''
 
                                     cleanWs()

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -41,13 +41,14 @@ pipeline {
                             //ghprbPullId = '12125'
                             //ghprbPullId = "${ghprbPullId}"
                             //ghprbTargetBranch = 'master'
+                            WMCORE_DEV_TAG = '0.2.0'
 
                             SLICES = 12
                         }
                         steps {
                             throttle(['DMWM-services']) {
                                 node( 'cms-dmwm-el9' ) {
-                                    git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
+                                    git branch: 'fix-12187', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                                     sh '''
                                     echo "$(TZ=GMT date): Job name is $JOB_NAME"
 

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -90,10 +90,14 @@ pipeline {
                                     '''
 
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                                        sh ''' 
-                                        echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
-                                        '''
+                                        retry(5) {
+                                            sh ''' 
+                                            echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
+                                            docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
+                                            '''
+
+                                            sleep(5)
+                                        }
 
                                         script {
                                             stash includes: 'artifacts/nosetests*.xml', name: "${SLICE}-artifacts", allowEmpty: true

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                             //ghprbPullId = '12125'
                             //ghprbPullId = "${ghprbPullId}"
                             //ghprbTargetBranch = 'master'
-                            WMCORE_DEV_TAG = '0.2.0'
+                            WMCORE_DEV_TAG = '0.2.0-stable'
 
                             SLICES = 12
                         }

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -83,8 +83,8 @@ pipeline {
                                     echo "User: $USER"
                                     whoami
 
-                                    echo "Starting containers"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d $TEST_SERVICE
+                                    #echo "Starting containers"
+                                    #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d $TEST_SERVICE
                                     sleep 20
 
                                     '''
@@ -93,7 +93,7 @@ pipeline {
                                         retry(5) {
                                             sh ''' 
                                             echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                            docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
+                                            docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
                                             '''
 
                                             sleep(5)

--- a/WMCore-TagBaseline/Jenkinsfile
+++ b/WMCore-TagBaseline/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'd0bc4ba6-d9c5-4668-9839-1b7ff6f795fe', variable: 'DMWMBOT_TOKEN')]) {
                     sh '''
-                    $WORKSPACE/docker/wmcore-dev/ContainerScripts/tagLatestWMCore.sh
+                    $WORKSPACE/ContainerScripts/tagLatestWMCore.sh
 
                     echo "Finishing up"
                     '''

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - couchdb
   
   wmcore-pr-pylint:
-    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
+    image: registry.cern.ch/cmsweb/wmcore-dev:${WMCORE_DEV_TAG}
     tty: true
     network_mode: "host"
     environment:
@@ -95,7 +95,7 @@ services:
   
   wmcore-pr-test:
     <<: *wma-base
-    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
+    image: registry.cern.ch/cmsweb/wmcore-dev:${WMCORE_DEV_TAG}
     network_mode: "host"
     environment:
       - ghprbPullId=${ghprbPullId}
@@ -131,7 +131,7 @@ services:
   
   wmcore-unittests:
     <<: *wma-base
-    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
+    image: registry.cern.ch/cmsweb/wmcore-dev:${WMCORE_DEV_TAG}
     network_mode: "host"
     environment:
       - MY_ID

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       - *sudoersd
       - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"
+      - "/etc/grid-security:/etc/grid-security:ro"
   
   wmcore-unittests:
     <<: *wma-base
@@ -142,3 +143,9 @@ services:
       - *sudoersd
       - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"
+      - "/etc/grid-security:/etc/grid-security:ro"
+    depends_on:
+      couchdb:
+        condition: service_healthy
+      mariadb:
+        condition: service_started

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -116,7 +116,7 @@ services:
   
   wmcore-unittests:
     <<: *wma-base
-    image: registry.cern.ch/cmsweb/wmcore-dev:20240925
+    image: registry.cern.ch/cmsweb/wmcore-dev:20241127-stable
     network_mode: "host"
     environment:
       - MY_ID

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - *group
       - *sudoers
       - *sudoersd
+      - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"
   
   wmcore-pr-test:
@@ -112,6 +113,7 @@ services:
       - *group
       - *sudoers
       - *sudoersd
+      - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"
   
   wmcore-unittests:

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - couchdb
   
   wmcore-pr-pylint:
-    image: registry.cern.ch/cmsweb/wmcore-dev:20240925
+    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
     tty: true
     network_mode: "host"
     environment:
@@ -87,7 +87,7 @@ services:
   
   wmcore-pr-test:
     <<: *wma-base
-    image: registry.cern.ch/cmsweb/wmcore-dev:20240925
+    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
     network_mode: "host"
     environment:
       - ghprbPullId=${ghprbPullId}

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       - MY_GROUP
       - WMA_CONFIG_FILE
       - BUILD_ID
-    user: root
+    user: cmsbld
     pull_policy: always
     volumes:
       - "/etc/condor:/etc/condor:ro"
@@ -141,4 +141,5 @@ services:
       - *group
       - *sudoers
       - *sudoersd
+      - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -125,7 +125,6 @@ services:
       - MY_GROUP
       - WMA_CONFIG_FILE
       - BUILD_ID
-    user: cmsbld
     pull_policy: always
     volumes:
       - "/etc/condor:/etc/condor:ro"

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -116,7 +116,7 @@ services:
   
   wmcore-unittests:
     <<: *wma-base
-    image: registry.cern.ch/cmsweb/wmcore-dev:20241127-stable
+    image: registry.cern.ch/cmsweb/wmcore-dev:20241202
     network_mode: "host"
     environment:
       - MY_ID

--- a/WMCore-Test-Base/docker-compose.yml
+++ b/WMCore-Test-Base/docker-compose.yml
@@ -46,6 +46,13 @@ services:
       - *group
       - *sudoers
       - *sudoersd
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5984 || exit 1"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+      start_interval: 5s
 
   wmagent: &wma-base
     <<: *common-service
@@ -116,6 +123,11 @@ services:
       - "${HOST_MOUNT_DIR}/home:/home/cmsbld"
       - "${HOST_MOUNT_DIR}/artifacts/:/home/cmsbld/artifacts/:Z"
       - "/etc/grid-security:/etc/grid-security:ro"
+    depends_on:
+      couchdb:
+        condition: service_healthy
+      mariadb:
+        condition: service_started
   
   wmcore-unittests:
     <<: *wma-base

--- a/WMCore-Test-Base/setup-env.sh
+++ b/WMCore-Test-Base/setup-env.sh
@@ -5,7 +5,7 @@ rm -rf $WORKSPACE/admin $WORKSPACE/certs $WORKSPACE/artifacts
 rm -rf $WORKSPACE/srv/{couchdb,mariadb,wmagent}  
 
 # make directories
-mkdir -p $WORKSPACE/admin/wmagent $WORKSPACE/admin/mariadb $WORKSPACE/certs $WORKSPACE/artifacts
+mkdir -p $WORKSPACE/admin/wmagent $WORKSPACE/admin/mariadb $WORKSPACE/certs $WORKSPACE/artifacts $WORKSPACE/home
 mkdir -p $WORKSPACE/srv/couchdb/${COUCH_TAG}/install
 mkdir -p $WORKSPACE/srv/couchdb/${COUCH_TAG}/logs
 mkdir -p $WORKSPACE/srv/couchdb/${COUCH_TAG}/state

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                         steps {
                             throttle(['DMWM-services']) {
                                 node( 'cms-dmwm-el9' ) {
-                                    git branch: 'main', url: 'https://github.com/dmwm/WMCore-Jenkins'
+                                    git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                                     sh '''
                                     echo "$(TZ=GMT date): Job name is $JOB_NAME"
 

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -78,15 +78,11 @@ pipeline {
                                     whoami
 
                                     echo "Starting containers"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d $TEST_SERVICE
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d mariadb couchdb
                                     sleep 10
 
                                     echo "Check docker ps output"
                                     docker ps
-
-                                    echo "--Check wmcore-unittests logs"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml logs wmcore-unittests
-                                    echo "--end of wmcore-unittests logs"
 
                                     echo "--Check MariaDB docker logs"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml logs mariadb
@@ -99,10 +95,11 @@ pipeline {
                                     echo "--Check CouchDB certificates"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T couchdb ls -l /data/certs
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T couchdb openssl x509 -in /data/certs/servicecert.pem -noout -dates -subject
-                                    echo "--Check WMCore-unittets certificates"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests ls -l /data/certs
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests openssl x509 -in /data/certs/servicecert.pem -noout -dates -subject
-                                    echo "--end of MariaDB docker envinronment"
+
+                                    #echo "--Check WMCore-unittests certificates"
+                                    #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests ls -l /data/certs
+                                    #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests openssl x509 -in /data/certs/servicecert.pem -noout -dates -subject
+                                    #echo "--end of WMCore-unittests docker envinronment"
 
 
                                     '''
@@ -110,7 +107,7 @@ pipeline {
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                         sh ''' 
                                         echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
+                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml run -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
                                         '''
 
                                         script {

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                             WMA_TAG = '2.3.3'
                             COUCH_TAG = '3.2.2'
                             MDB_TAG = '10.6.19'
-                            WMCORE_DEV_TAG = '0.2.0'
+                            WMCORE_DEV_TAG = '0.2.0-stable'
 
                             ghprbPullId = '11995'
                             ghprbTargetBranch = 'master'

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
 
                                     echo "Starting containers"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml up --quiet-pull -d mariadb couchdb
-                                    sleep 10
+                                    sleep 20
 
                                     echo "Check docker ps output"
                                     docker ps
@@ -100,8 +100,6 @@ pipeline {
                                     #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests ls -l /data/certs
                                     #docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T wmcore-unittests openssl x509 -in /data/certs/servicecert.pem -noout -dates -subject
                                     #echo "--end of WMCore-unittests docker envinronment"
-
-
                                     '''
 
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                         sh ''' 
                                         echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/WMCore-Jenkins/docker/wmcore-dev/TestScripts/test-wmcorepy3.sh
+                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
                                         '''
 
                                         script {

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
                             WMA_TAG = '2.3.3'
                             COUCH_TAG = '3.2.2'
                             MDB_TAG = '10.6.19'
+                            WMCORE_DEV_TAG = '0.2.0'
 
                             ghprbPullId = '11995'
                             ghprbTargetBranch = 'master'
@@ -46,7 +47,7 @@ pipeline {
                         steps {
                             throttle(['DMWM-services']) {
                                 node( 'cms-dmwm-el9' ) {
-                                    git branch: 'test-20241127-image', url: 'https://github.com/d-ylee/WMCore-Jenkins'
+                                    git branch: 'fix-12187', url: 'https://github.com/d-ylee/WMCore-Jenkins'
                                     sh '''
                                     echo "$(TZ=GMT date): Job name is $JOB_NAME"
 

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -84,13 +84,17 @@ pipeline {
                                     echo "Check docker ps output"
                                     docker ps
 
+                                    echo "--Check wmcore-unittests logs"
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml logs wmcore-unittests
+                                    echo "--end of wmcore-unittests logs"
+
                                     echo "--Check MariaDB docker logs"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml logs mariadb
-                                    echo "--end of MariaDB docker envinronment"
+                                    echo "--end of MariaDB docker environment"
 
                                     echo "--Check CouchDB docker logs"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml logs couchdb
-                                    echo "--end of MariaDB docker envinronment"
+                                    echo "--end of MariaDB docker environment"
 
                                     echo "--Check CouchDB certificates"
                                     docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -T couchdb ls -l /data/certs
@@ -106,7 +110,7 @@ pipeline {
                                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                         sh ''' 
                                         echo "Testing slice $SLICE of $SLICES for build $BUILD_ID"
-                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/TestScripts/test-wmcorepy3.sh
+                                        docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml exec -u $MY_ID -e BUILD_ID=$BUILD_ID -e SLICES=$SLICES -e SLICE=$SLICE $TEST_SERVICE /home/cmsbld/WMCore-Jenkins/docker/wmcore-dev/TestScripts/test-wmcorepy3.sh
                                         '''
 
                                         script {

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -57,9 +57,9 @@ pipeline {
                                     docker compose version
 
                                     echo "Make sure all containers are stopped"
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down mariadb
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down couchdb
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down $TEST_SERVICE --rmi all
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down mariadb --rmi all
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down couchdb --rmi all
 
                                     echo "Docker ps:"
                                     docker ps
@@ -119,7 +119,7 @@ pipeline {
                                     }
 
                                     sh '''
-                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down
+                                    docker compose -f $WORKSPACE/WMCore-Test-Base/docker-compose.yml down --rmi all
                                     '''
 
                                     cleanWs()

--- a/docker/wmcore-dev/TestScripts/test-wmcorepy3.sh
+++ b/docker/wmcore-dev/TestScripts/test-wmcorepy3.sh
@@ -28,11 +28,10 @@ export COUCHURL="http://${COUCH_USER}:${COUCH_PASS}@${COUCH_HOST}:${COUCH_PORT}"
 # ensure db exists
 # retry if fails
 
-
-for i in 1 2 3 4 5; do
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    echo "Attempt $i to create mariadb database..."
     mysql -u ${MDB_USER} -h 127.0.0.1 -p${MDB_PASS} --execute "CREATE DATABASE IF NOT EXISTS ${MDB_UNITTEST_DB}" && break
 
-    echo "Attempt $i failed. Trying again..."
     sleep 5
 done
 

--- a/etc/rucio.cfg-temp
+++ b/etc/rucio.cfg-temp
@@ -1,0 +1,20 @@
+# Copyright European Organization for Nuclear Research (CERN)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Vincent Garonne, <vgaronne@gmail.com>, 2017
+# - Eric Vaandering, <ewv@fnal.gov>, 2018
+
+[common]
+[client]
+rucio_host = http://cms-rucio-int.cern.ch
+auth_host = https://cms-rucio-auth-int.cern.ch
+auth_type = x509
+ca_cert = /etc/grid-security/certificates/
+client_cert = $X509_USER_CERT
+client_key = $X509_USER_KEY
+client_x509_proxy = $X509_USER_PROXY
+request_retries = 3


### PR DESCRIPTION
Fixes dmwm/WMCore#12187

The fixes here are coupled with changes in dmwm/CMSKubernetes#1568

## Major Changes

### Script locations
TestScripts, ContainerScripts, and the etc directory are now moved to the root directory. Original location of docker/wmcore-dev still exists, but will be deprecated in a future release

### User Permissions
wmcore-pr-test and wmcore-unittests are now run as the main user, not root user. As a result, a new directory, $WORKSPACE/home is added. It is bind mounted to /home/cmsbld in images to avoid some permissions/chown operations

### Service Deployment
Most commands are now using `docker compose run` instead of `docker compose exec`. This, coupled with using the `depends_on` in the compose files, seem to work fine. One future implementation would be to also give MariaDB a health check option, as indicated here: https://github.com/dmwm/WMCore/issues/12198

### Versioning
This iteration of WMCore-Jenkins should be used with the `wmcore-dev:0.2.0-stable` image.