### PR TITLE
Add job execution timeout of 30 minutes to all jobs

### DIFF
--- a/WMCore-Aggregate-Baseline/Jenkinsfile
+++ b/WMCore-Aggregate-Baseline/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'cms-dmwm-el9'
     }
 
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
     environment {
         CODE_REPO = "WMCore"
         WMCORE_REPO = "dmwm"

--- a/WMCore-PR-Report/Jenkinsfile
+++ b/WMCore-PR-Report/Jenkinsfile
@@ -6,6 +6,10 @@ pipeline {
         label 'cms-dmwm-el9'
    }
 
+   options {
+       timeout(time: 30, unit: 'MINUTES')
+   }
+
     environment {
         CODE_REPO = "WMCore"
         WMCORE_REPO = "dmwm"

--- a/WMCore-PR-pylint/Jenkinsfile
+++ b/WMCore-PR-pylint/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'cms-dmwm-el9'
     }
 
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
     parameters {
         string(name: 'ghprbPullId', defaultValue: '')
 

--- a/WMCore-PR-test/Jenkinsfile
+++ b/WMCore-PR-test/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'cms-dmwm-el9'
     }
 
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
     stages {
         stage('Matrix') {
             matrix {

--- a/WMCore-TagBaseline/Jenkinsfile
+++ b/WMCore-TagBaseline/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'cms-dmwm-el9'
     }
 
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
     environment {
         WMCORE_REPO = "dmwm"
         TAG_PREFIX = "JENKINS_EL9"

--- a/WMCore-unittests-baseline/Jenkinsfile
+++ b/WMCore-unittests-baseline/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'cms-dmwm-el9'
     }
 
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+
     stages {
         stage('Matrix') {
             matrix {


### PR DESCRIPTION
Given that we started seeing rogue Jenkins jobs running for hours, I decided to make this hard limit of 30min execution for all of our jobs (baseline and PR-triggered jobs).